### PR TITLE
move esip submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 	url = https://github.com/pangeo-gallery/physical-oceanography.git
 	branch = binderbot-built
 [submodule "repos/pangeo-gallery/esip-gallery"]
-	path = repos/pangeo-gallery/esip-gallery
+	path = repos/rsignell-usgs/esip-gallery
 	url = https://github.com/rsignell-usgs/esip-gallery.git
 	branch = binderbot-built


### PR DESCRIPTION
The PR in #4 used the wrong path for the submodule. It should be `repos/<owner>/<repo_name>`. The owner of the `esip-gallery` repo is `rsignell`, not `pangeo-gallery`. This is not clear enough in the docs.

cc @rsignell-usgs 