### PR TITLE
Add git submodule from an issue comment

### DIFF
--- a/.github/workflows/add-submodule.yml
+++ b/.github/workflows/add-submodule.yml
@@ -26,7 +26,7 @@ jobs:
           script: |
             const fs = require('fs')
             const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
-            const gallery_repo = payload.issue.body.split(' ')[1]
+            const gallery_repo = payload.issue.body.split('/add-submodule')[1].trim()
             const repo_url = `https://github.com/${gallery_repo}.git`
             const issue_reply = `👋 Thanks for integrating [${gallery_repo}](${repo_url}) repo with Pangeo Gallery!`
             // Send a reply message to the issue

--- a/.github/workflows/add-submodule.yml
+++ b/.github/workflows/add-submodule.yml
@@ -37,11 +37,11 @@ jobs:
               body: issue_reply
             })
             // Create Pull request and reference originating issue
-            const message = `Adding [${gallery_repo}](${repo_url}) to the Pangeo Gallery as it was requested in #${context.issue.number}`
+            const message = `Adding [${gallery_repo}](${repo_url}) to the Pangeo Gallery as requested in #${context.issue.number}`
             github.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Integrating ${gallery_repo} with Pangeo Gallery`,
+              title: `Integrate ${gallery_repo} with Pangeo Gallery`,
               head: gallery_repo,
               base: 'master',
               body: message

--- a/.github/workflows/add-submodule.yml
+++ b/.github/workflows/add-submodule.yml
@@ -1,0 +1,48 @@
+name: Add Git Submodule
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-submodule-from-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Add repo as submodule and commit changes
+        run: |
+          python .github/workflows/scripts/add_submodule.py
+
+      - name: Create PR
+        uses: actions/github-script@0.9.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs')
+            const payload = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'))
+            const gallery_repo = payload.issue.body.split(' ')[1]
+            const repo_url = `https://github.com/${gallery_repo}.git`
+            const issue_reply = `👋 Thanks for integrating [${gallery_repo}](${repo_url}) repo with Pangeo Gallery!`
+            // Send a reply message to the issue
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: issue_reply
+            })
+            // Create Pull request and reference originating issue
+            const message = `Adding [${gallery_repo}](${repo_url}) to the Pangeo Gallery as it was requested in #${context.issue.number}`
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Integrating ${gallery_repo} with Pangeo Gallery`,
+              head: gallery_repo,
+              base: 'master',
+              body: message
+              })

--- a/.github/workflows/scripts/add_submodule.py
+++ b/.github/workflows/scripts/add_submodule.py
@@ -1,0 +1,25 @@
+import os, json, subprocess, sys
+
+if __name__ == '__main__':
+    with open(os.environ['GITHUB_EVENT_PATH'], 'r') as f:
+        ev = json.load(f)
+    comment = ev['issue']['body']
+    if comment.startswith('/add-submodule'):
+        repo = comment.split('/add-submodule')[-1].strip()
+        repo_url = f'https://github.com/{repo}.git'
+        res = subprocess.run(
+            f'git ls-remote {repo_url}', shell=True, stdout=subprocess.PIPE
+        )
+        if res.returncode == 128:
+            print(f'{repo_url} does not appear to be a git repository')
+            sys.exit(1)
+        else:
+            command = f'git checkout -b {repo} && git submodule add -b binderbot-built {repo_url} repos/{repo}'
+            subprocess.check_call(command, shell=True, stdout=subprocess.PIPE)
+            git_config_id = 'git config --global user.email "action@github.com" && git config --global user.name "GitHub Action"'
+            git_commit = 'git add . && git commit -m "Setup repo"'
+            git_push = f'git push -f --set-upstream origin {repo}'
+            command = f"""{git_config_id} && {git_commit} && {git_push}"""
+            subprocess.check_call(command, shell=True, stdout=subprocess.PIPE)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
Towards fixing #2 

This workflow works as follows:

1. A user opens an issue with a comment containing the `/add-submodule` command. For example: `/add-submodule pangeo-gallery/physical-oceanography`

2. The GH workflow is triggered when an issue is created

3. The workflow inspects the issue payload 
   
   a. if the body starts with `/add-submodule`. 
   	1. Extract the repo reference
    2. Construct the GitHub repo url
    3. Use the `git ls-remote repo_url` command to check if the repo_url is valid/exist
          - if the repo_url is valid: continue
          - else: exit with `sys.exit(1)`
    4. Add the repo as a git submodule
    5. Create an issue comment
    6. Create a PR and reference the issue

   b. else: exit with `sys.exit(1)`


**Example**:

1. Create an issue with a comment starting with `/add-submodule`:

![Screen Shot 2020-04-28 at 1 41 35 PM](https://user-images.githubusercontent.com/13301940/80531279-9862e700-8957-11ea-8f76-3a65c6d22967.png)


2. The Workflow triggers a pull request creation:

![Screen Shot 2020-04-28 at 1 41 49 PM](https://user-images.githubusercontent.com/13301940/80531274-9731ba00-8957-11ea-9fdc-3b526279d6af.png)

 