### PR TITLE
add sphinxcontrib-googleanalytics extension

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,11 +34,14 @@ import sphinx_pangeo_theme
 extensions = [
     'nbsphinx',
     'sphinx.ext.mathjax',
-    'sphinxcontrib.fulltoc'
+    'sphinxcontrib.fulltoc',
+    'sphinxcontrib.googleanalytics'
 ]
 
 nbsphinx_timeout = 600
 nbsphinx_execute = "never"
+googleanalytics_id = 'UA-262-797-369'    # google analytics property
+
 # not working yet
 # nbsphinx_prolog = """
 # {% set docname = env.doc2path(env.docname, base=None) %}

--- a/conf.py
+++ b/conf.py
@@ -28,6 +28,13 @@ import sphinx_pangeo_theme
 #
 # needs_sphinx = '1.0'
 
+# Workaround for issue https://github.com/sphinx-contrib/googleanalytics/issues/2
+# Note that a warning still will be issued "unsupported object from its setup() function"
+# Remove this workaround when the issue has been resolved upstream
+import sphinx.application
+import sphinx.errors
+sphinx.application.ExtensionError = sphinx.errors.ExtensionError
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ doctr
 sphinx-copybutton
 sphinxcontrib-srclinks
 sphinxcontrib-fulltoc
+sphinxcontrib-googleanalytics
 git+https://github.com/pangeo-gallery/binderbot


### PR DESCRIPTION
As discussed [here](https://github.com/pangeo-gallery/pangeo-gallery/issues/55), this adds `sphinxcontrib-googleanalytics `to the requirements.txt and a `'sphinxcontrib.googleanalytics'` and ` googleanalytics_id = 'UA-262-797-369' `   to conf.py in order to add google analytics to the example galleries webpage.
