### PR TITLE
Add link to the Pythia Cookbook gallery

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,6 +8,10 @@ Each gallery is hosted in a standalone GitHub repository.
 If you're interested in contributing a new gallery, please see the
 :doc:`contributing`.
 
+Note that some of this content has migrated over to the 
+`Project Pythia Cookbook Gallery <https://cookbooks.projectpythia.org>`_ 
+which is under active develpment.
+
 .. raw:: html
 
     <div class="row">


### PR DESCRIPTION
Adds a sentence and a link to the Project Pythia Cookbook Gallery on the home page.

I thought this might be helpful since some of the Pangeo Gallery content has already migrated over to Cookbooks, and the Cookbooks are under active development.